### PR TITLE
TTP2-26 Application Runtime Error due to mismatch datatype

### DIFF
--- a/src/main/java/com/nus/iss/tasktracker/repository/TaskInfoRepository.java
+++ b/src/main/java/com/nus/iss/tasktracker/repository/TaskInfoRepository.java
@@ -30,7 +30,7 @@ public interface TaskInfoRepository extends  JpaRepository<TaskInfo, Integer> {
 
     Optional<TaskInfo> findByDeleteFlagAndTaskId(String deleteFlag, int taskId );
 
-    List<TaskInfo> findByTaskAssigneeAndTaskStatus(String userId, String taskStatus);
+    List<TaskInfo> findByTaskAssigneeAndTaskStatus(int userId, String taskStatus);
 }
 
 

--- a/src/main/java/com/nus/iss/tasktracker/service/TaskInfoService.java
+++ b/src/main/java/com/nus/iss/tasktracker/service/TaskInfoService.java
@@ -16,7 +16,7 @@ public interface TaskInfoService {
 
     public Integer findTaskRewardPointsByGroupId(Integer userId);
 
-    void releaseActiveTaskAssignedToUser(String userId);
+    void releaseActiveTaskAssignedToUser(int userId);
 
 
 }

--- a/src/main/java/com/nus/iss/tasktracker/service/impl/TaskInfoServiceImpl.java
+++ b/src/main/java/com/nus/iss/tasktracker/service/impl/TaskInfoServiceImpl.java
@@ -330,7 +330,7 @@ public TaskInfoDTO updateTask(int taskId,TaskInfoDTO requestDTO){
     }
 
     @Override
-    public void releaseActiveTaskAssignedToUser(String userId){
+    public void releaseActiveTaskAssignedToUser(int userId){
         List<TaskInfo> tasks=taskInfoRepository.findByTaskAssigneeAndTaskStatus(userId,"Pending");
 
         for (TaskInfo task : tasks){


### PR DESCRIPTION
- Change the `userId` data type from `String` to `int` to match the data type in the `user_info` table.